### PR TITLE
Update dependency source for caravaggio, the right branch is develop

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ python_requires = >=3.0,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 
 dependency_links =
     git+ssh://git@github.com/buildgroupai/django-cassandra-engine.git@bgds-1#egg=django-cassandra-engine-1.5.5-bgds-1
-    git+ssh://git@github.com/buildgroupai/django-caravaggio-rest-api.git@clients-support_external-systems#egg=django-caravaggio-rest-api-0.1.7-SNAPSHOT
+    git+ssh://git@github.com/buildgroupai/django-caravaggio-rest-api.git@develop#egg=django-caravaggio-rest-api-0.1.7-SNAPSHOT
 
 
 [options.extras_require]


### PR DESCRIPTION
The caravaggio dependency should be pointing to the branch `develop`