### PR TITLE
Correct problems with selenium-wire

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,7 @@ install_requires =
     XlsxWriter>=1.1.2
     django-cassandra-engine==1.5.5.bgds-1
     django-caravaggio-rest-api==0.1.7-SNAPSHOT
+    selenium-wire>=1.0.10
 
 
 test_requires =

--- a/src/davinci_crawling/crawler.py
+++ b/src/davinci_crawling/crawler.py
@@ -18,7 +18,8 @@ from django.core.management.base import DjangoHelpFormatter
 
 from davinci_crawling.time import mk_datetime
 
-from seleniumwire import webdriver
+from selenium import webdriver
+from seleniumwire import webdriver as wire_webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
@@ -73,7 +74,8 @@ class Crawler(metaclass=ABCMeta):
             chrome_options.add_argument("--disable-features=NetworkService")
 
             proxy_address = cls.proxy_manager.get_proxy_address()
-            proxy_address = {"proxy": proxy_address}
+            if proxy_address:
+                proxy_address = {"proxy": proxy_address}
 
             chrome_options.binary_location = chromium_file
 
@@ -85,7 +87,7 @@ class Crawler(metaclass=ABCMeta):
                     capabilities[key] = value
 
             if proxy_address:
-                driver = webdriver.Chrome(
+                driver = wire_webdriver.Chrome(
                     chrome_options=chrome_options,
                     desired_capabilities=capabilities,
                     seleniumwire_options=proxy_address)


### PR DESCRIPTION
- Correct problems with selenium-wire that was receiving timeout after the second request, now we just use selenium-wire when we indeed have to use proxy.