### PR TITLE
Remove setup_cassandra_object_mapper on bovespa

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Improvements or Changes
 - Change the key used on throttle from `<function_name>` to `<crawler_name>_<function_name>_<throttle_suffix>`
 - Add maintenance status to the task;
 - Add a `more_info` field to the task;
+- Remove unnecessary usage of the setup_cassandra_object_mapper inside the bovespa crawler;
 
 Bug Fixing
 **********

--- a/src/davinci_crawling/crawler.py
+++ b/src/davinci_crawling/crawler.py
@@ -26,6 +26,12 @@ from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 _logger = logging.getLogger("davinci_crawling")
 
+CHROME_OPTIONS = Options()
+CHROME_OPTIONS.add_argument("--headless")
+CHROME_OPTIONS.add_argument("--no-sandbox")
+CHROME_OPTIONS.add_argument("--disable-gpu")
+CHROME_OPTIONS.add_argument("--disable-features=NetworkService")
+
 
 def get_configuration(crawler_name):
     return settings.DAVINCI_CRAWLERS[crawler_name] \
@@ -67,17 +73,11 @@ class Crawler(metaclass=ABCMeta):
         chromium_file = options.get("chromium_bin_file", None)
         path = os.path.dirname(os.path.abspath(__file__))
         if chromium_file:
-            chrome_options = Options()
-            chrome_options.add_argument("--headless")
-            chrome_options.add_argument("--no-sandbox")
-            chrome_options.add_argument("--disable-gpu")
-            chrome_options.add_argument("--disable-features=NetworkService")
-
             proxy_address = cls.proxy_manager.get_proxy_address()
             if proxy_address:
                 proxy_address = {"proxy": proxy_address}
 
-            chrome_options.binary_location = chromium_file
+            CHROME_OPTIONS.binary_location = chromium_file
 
             capabilities = DesiredCapabilities.CHROME
 
@@ -88,12 +88,12 @@ class Crawler(metaclass=ABCMeta):
 
             if proxy_address:
                 driver = wire_webdriver.Chrome(
-                    chrome_options=chrome_options,
+                    chrome_options=CHROME_OPTIONS,
                     desired_capabilities=capabilities,
                     seleniumwire_options=proxy_address)
             else:
-                driver = webdriver.Chrome(
-                    chrome_options=chrome_options,
+                driver = wire_webdriver.Chrome(
+                    chrome_options=CHROME_OPTIONS,
                     desired_capabilities=capabilities)
 
             _logger.info("Using CHROMIUM as Dynamic Web Driver. Driver {}".

--- a/src/davinci_crawling/example/bovespa/crawling_parts/crawl_companies_files.py
+++ b/src/davinci_crawling/example/bovespa/crawling_parts/crawl_companies_files.py
@@ -14,8 +14,7 @@ from davinci_crawling.example.bovespa import BOVESPA_CRAWLER
 from davinci_crawling.example.bovespa.models import \
     BovespaCompany, BovespaCompanyFile, DOC_TYPES
 from davinci_crawling.throttle.throttle import Throttle
-from davinci_crawling.utils import setup_cassandra_object_mapper, \
-    CrawlersRegistry
+from davinci_crawling.utils import CrawlersRegistry
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -231,10 +230,6 @@ def obtain_company_files(
 
     Returns: the files that we downloaded from company.
     """
-    # We need to setup the Cassandra Object Mapper to work on multiprocessing
-    # If we do not do that, the processes will be blocked when interacting
-    # with the object mapper module
-    setup_cassandra_object_mapper()
 
     files = []
     driver = None

--- a/src/davinci_crawling/example/bovespa/crawling_parts/crawl_listed_companies.py
+++ b/src/davinci_crawling/example/bovespa/crawling_parts/crawl_listed_companies.py
@@ -13,8 +13,7 @@ from davinci_crawling.example.bovespa import BOVESPA_CRAWLER
 from davinci_crawling.example.bovespa.models import \
     BovespaCompany, SITUATION_CANCELLED, SITUATION_GRANTED
 from davinci_crawling.throttle.throttle import Throttle
-from davinci_crawling.utils import setup_cassandra_object_mapper, \
-    CrawlersRegistry
+from davinci_crawling.utils import CrawlersRegistry
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
@@ -42,11 +41,6 @@ def update_listed_companies(letter, options):
     :param driver:
     :return:
     """
-
-    # We need to setup the Cassandra Object Mapper to work on multiprocessing
-    # If we do not do that, the processes will be blocked when interacting
-    # with the object mapper module
-    setup_cassandra_object_mapper()
 
     driver = None
     try:

--- a/src/davinci_crawling/management/commands/utils/consumer.py
+++ b/src/davinci_crawling/management/commands/utils/consumer.py
@@ -8,7 +8,6 @@ from threading import Thread
 
 from davinci_crawling.management.commands.utils.utils import \
     update_task_status, get_crawler_by_name
-from davinci_crawling.utils import setup_cassandra_object_mapper
 
 from multiprocessing import Queue
 
@@ -64,11 +63,6 @@ class CrawlConsumer(object):
         Returns:
             The result of the crawler call.
         """
-        # We need to setup the Cassandra Object Mapper to work on
-        # multiprocessing If we do not do that, the processes will be blocked
-        # when interacting with the object mapper module
-        setup_cassandra_object_mapper()
-
         crawler = get_crawler_by_name(crawler_name)
         _logger.debug("Calling crawl method: {0}".
                       format(getattr(crawler, "crawl")))


### PR DESCRIPTION
**Changes**
*  Remove unnecessary usage of the setup_cassandra_object_mapper inside the Bovespa crawler;

**Bugs Fixed**
* Corrected a bug on connecting to Cassandra when using multiple threads on the Bovespa crawler.

**Tests**
* None
